### PR TITLE
Parameterizing first/last valid user/group IDs

### DIFF
--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -33,7 +33,7 @@ class dovecot::mail (
     gid    => $gid,
   }
 
-  user { $username :
+  user { $username:
     ensure     => present,
     gid        => $gid,
     home       => $userhome,
@@ -41,11 +41,12 @@ class dovecot::mail (
     uid        => $uid,
     require    => Group[$groupname]
   }
-  file { $userhome :
-    ensure => directory,
-    owner => $username,
-    group    => $groupname,
-    mode     => '0750',
-    require  => User[$username],
+
+  file { $userhome:
+    ensure  => directory,
+    owner   => $username,
+    group   => $groupname,
+    mode    => '0750',
+    require => User[$username],
   }
 }


### PR DESCRIPTION
This just adds some more parameterization, and does it cleanly on its own feature branch :)

I needed to adjust these as I was using a system user rather than virtual users. As is, the defaults remain the same.
