### PR TITLE
Auth worker fix

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -8,6 +8,7 @@ class dovecot::master (
   $postfix_mod       = '0666',
   $postfix_path      = '/var/spool/postfix/private/auth',
   $auth_worker_user  = '$default_internal_user',
+  $auth_worker_group = undef,
 ) {
   include dovecot
 
@@ -60,9 +61,18 @@ class dovecot::master (
     require     => Dovecot::Config::Dovecotcfmulti['/etc/dovecot/conf.d/10-master.conf-userdblistener0'],
   }
 
-  dovecot::config::dovecotcfmulti { 'master':
+  dovecot::config::dovecotcfmulti { '/etc/dovecot/conf.d/10-master.conf-auth-worker-user':
     config_file => 'conf.d/10-master.conf',
     changes     => ["set service[ . = \"auth-worker\"]/user ${auth_worker_user}",],
-    require     => Dovecot::Config::Dovecotcfmulti['/etc/dovecot/conf.d/10-master.conf-userdblistener1']
+  }
+
+  if $auth_worker_group != undef {
+
+    notice("auth-worker group parameter can only be unset manually")
+
+    dovecot::config::dovecotcfmulti { '/etc/dovecot/conf.d/10-master.conf-auth-worker-group':
+      config_file => 'conf.d/10-master.conf',
+      changes     => ["set service[ . = \"auth-worker\"]/group ${auth_worker_group}",],
+    }
   }
 }


### PR DESCRIPTION
It's handy to be able to set the auth-worker user. It's even handier to be able to set the auth-worker group. If  the shadow file needs to be read by the auth-worker (for system accounts), the group can be set to 'shadow' (you could also set the user to root, but the former is preferable). This is per the [Dovecot Wiki](http://wiki2.dovecot.org/UserIds).

The title of the auth-worker user resource was adjusted, as `master` didn't make sense. Also, the require on `userdblistener1` seems wholly unnecessary to me; I was able to re-apply without problem, but it may be wise to test this on a fresh install. Still, auth-worker user and group aren't nested under anything in `conf.d/10-master.conf`, which is the only thing I know of that would necessitate a require dependency.

P.S. This PR is clean too.
