### PR TITLE
Refactoring SSL setup

### DIFF
--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -1,9 +1,10 @@
 class dovecot::ssl (
-  $ssl = 'no',
+  $ssl          = 'no',
   $ssl_certfile = undef,
-  $ssl_keyfile = undef,
-  $ssl_ca = undef,
-) {
+  $ssl_keyfile  = undef,
+  $ssl_ca       = undef,
+  ) {
+
   include dovecot
 
   dovecot::config::dovecotcfsingle { 'ssl':
@@ -11,27 +12,39 @@ class dovecot::ssl (
     value       => $ssl,
   }
 
-  if ssl == 'yes' {
+  if $ssl_certfile != undef {
     dovecot::config::dovecotcfsingle { 'ssl_cert':
       config_file => 'conf.d/10-ssl.conf',
-      value       => "'<${ssl_certfile}'",
+      value       => "<${ssl_certfile}",
     }
-
-    if ssl_ca {
-      dovecot::config::dovecotcfsingle { 'ssl_ca':
-        config_file => 'conf.d/10-ssl.conf',
-        value       => "'<${ssl_ca}'",
-      }
-    } else {
-      dovecot::config::dovecotcfsingle { 'ssl_ca':
-        ensure      => absent,
-        config_file => 'conf.d/10-ssl.conf',
-      }
+  } else {
+    dovecot::config::dovecotcfsingle { 'ssl_cert':
+      ensure      => absent,
+      config_file => 'conf.d/10-ssl.conf',
     }
+  }
 
+  if $ssl_ca != undef {
+    dovecot::config::dovecotcfsingle { 'ssl_ca':
+      config_file => 'conf.d/10-ssl.conf',
+      value       => "<${ssl_ca}",
+    }
+  } else {
+    dovecot::config::dovecotcfsingle { 'ssl_ca':
+      ensure      => absent,
+      config_file => 'conf.d/10-ssl.conf',
+    }
+  }
+
+  if $ssl_keyfile != undef {
     dovecot::config::dovecotcfsingle { 'ssl_key':
       config_file => 'conf.d/10-ssl.conf',
-      value       => "'<${ssl_keyfile}'",
+      value       => "<${ssl_keyfile}",
+    }
+  } else {
+    dovecot::config::dovecotcfsingle { 'ssl_key':
+      ensure      => absent,
+      config_file => 'conf.d/10-ssl.conf',
     }
   }
 }


### PR DESCRIPTION
- Fixing `if ssl` -> `if $ssl` (not a variable comparison)
- Comparing `$ssl` to `undef`, not `yes`, so that `required` can be used
  as well
- Single quotes for `ssl_cert`, `ssl_key`, and `ssl_ca` are unnecessary per
  the [Dovecot Wiki](http://wiki2.dovecot.org/SSL/DovecotConfiguration)
- For any setting that is `undef`, the respective configuration is removed

This PR is clean as well.
