### PR TITLE
Parameterizing auth-worker user and group

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -61,13 +61,13 @@ class dovecot::master (
     require     => Dovecot::Config::Dovecotcfmulti['/etc/dovecot/conf.d/10-master.conf-userdblistener0'],
   }
 
-  dovecot::config::dovecotcfsingle { "service[ . = 'auth-worker']/user":
+  dovecot::config::dovecotcfsingle { "service[ . = \"auth-worker\"]/user":
     ensure      => $auth_worker_user ? { false => absent, default => present },
     config_file => 'conf.d/10-master.conf',
     value       => $auth_worker_user,
   }
 
-  dovecot::config::dovecotcfsingle { "serivce[ . = 'auth-worker']/group":
+  dovecot::config::dovecotcfsingle { "service[ . = \"auth-worker\"]/group":
     ensure      => $auth_worker_group ? { false => absent, default => present },
     config_file => 'conf.d/10-master.conf',
     value       => $auth_worker_group,


### PR DESCRIPTION
Using `dovecot::config::dovecotcfsingle` and selector to more easily remove these parameters if set to 'false'. Tested and this works to both enable and remove. Much cleaner than the `dovecotcfmulti`, thanks for the tip :)

> It's handy to be able to set the auth-worker user. It's even handier to be able to set the auth-worker group. If  the shadow file needs to be read by the auth-worker (for system accounts), the group can be set to 'shadow' (you could also set the user to root, but the former is preferable). This is per the [Dovecot Wiki](http://wiki2.dovecot.org/UserIds).
