### PR TITLE
Using selectors to set ensure

### DIFF
--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -1,8 +1,8 @@
 class dovecot::ssl (
   $ssl          = 'no',
-  $ssl_certfile = undef,
-  $ssl_keyfile  = undef,
-  $ssl_ca       = undef,
+  $ssl_certfile = false,
+  $ssl_keyfile  = false,
+  $ssl_ca       = false,
   ) {
 
   include dovecot
@@ -12,39 +12,21 @@ class dovecot::ssl (
     value       => $ssl,
   }
 
-  if $ssl_certfile != undef {
-    dovecot::config::dovecotcfsingle { 'ssl_cert':
-      config_file => 'conf.d/10-ssl.conf',
-      value       => "<${ssl_certfile}",
-    }
-  } else {
-    dovecot::config::dovecotcfsingle { 'ssl_cert':
-      ensure      => absent,
-      config_file => 'conf.d/10-ssl.conf',
-    }
+  dovecot::config::dovecotcfsingle { 'ssl_cert':
+    ensure      => $ssl_certfile ? { false => absent, default => present },
+    config_file => 'conf.d/10-ssl.conf',
+    value       => "<${ssl_certfile}",
   }
 
-  if $ssl_ca != undef {
-    dovecot::config::dovecotcfsingle { 'ssl_ca':
-      config_file => 'conf.d/10-ssl.conf',
-      value       => "<${ssl_ca}",
-    }
-  } else {
-    dovecot::config::dovecotcfsingle { 'ssl_ca':
-      ensure      => absent,
-      config_file => 'conf.d/10-ssl.conf',
-    }
+  dovecot::config::dovecotcfsingle { 'ssl_key':
+    ensure      => $ssl_keyfile ? { false => absent, default => present },
+    config_file => 'conf.d/10-ssl.conf',
+    value       => "<${ssl_keyfile}",
   }
 
-  if $ssl_keyfile != undef {
-    dovecot::config::dovecotcfsingle { 'ssl_key':
-      config_file => 'conf.d/10-ssl.conf',
-      value       => "<${ssl_keyfile}",
-    }
-  } else {
-    dovecot::config::dovecotcfsingle { 'ssl_key':
-      ensure      => absent,
-      config_file => 'conf.d/10-ssl.conf',
-    }
+  dovecot::config::dovecotcfsingle { 'ssl_ca':
+    ensure      => $ssl_ca ? { false => absent, default => present },
+    config_file => 'conf.d/10-ssl.conf',
+    value       => "<${ssl_ca}",
   }
 }


### PR DESCRIPTION
This refactors it a lot more nicely than I'd done previously. However, checking against `undef` I've found can be a little surprising (for one, you have to use the default, you can't pass `undef` as a value, at least not from Hiera), so instead of `undef`, I'm using the boolean `false`, which can be passed around safely.

I tested this on my Vagrant box, it properly removes the settings when the corresponding variable is `false`. Much cleaner. Thanks for turning me on to the proper use of `dovecotcfsingle` (and more generally, Augeas).
