### PR TITLE
More parameters for IMAP

### DIFF
--- a/manifests/imap.pp
+++ b/manifests/imap.pp
@@ -1,6 +1,6 @@
 class dovecot::imap (
   $mail_plugins                = '$mail_plugins imap_quota',
-  $mail_max_userip_connections = 10,
+  $mail_max_userip_connections = 3,
   $imap_idle_notify_interval   = '29 mins'
   ) {
 


### PR DESCRIPTION
- mail_max_userip_connections: set to default of 10
- imap_idle_notify_interval: set to default of '2 mins'

Using dovecotcfmulti since there are several parameters

Bugfix: mail_plugins should be set inside the 'protocol imap' block

There is a global mail_plugins that is already set in `dovecot::mail`.

Tested, correctly sets the values on my server.
