### PR TITLE
Fixed RHEL issues with init.pp and made auth-passwd template work.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,34 +1,19 @@
 class dovecot {
 
-  $imap_package_name = $::osfamily ? {
-    'Debian' => 'dovecot-imapd',
-    'Redhat' => 'dovecot-imapd',
-    default  => 'dovecot-imapd',
+  $mailpackages = $::osfamily ? {
+    default  => ['dovecot-imapd', 'dovecot-pop3d'],
+    'Debian' => ['dovecot-imapd', 'dovecot-pop3d'],
+    'Redhat' => ['dovecot',]
   }
 
-  package { $imap_package_name:
-    ensure => installed,
-    alias  => 'dovecot',
-    before => Exec['dovecot']
-  }
-
-  $pop3_package_name = $::osfamily ? {
-    'Debian' => 'dovecot-pop3d',
-    'Redhat' => 'dovecot',
-    default  => 'dovecot-pop3d',
-  }
-
-  package { $pop3_package_name:
-    ensure => installed,
-    alias  => 'dovecot-pop3d',
-    before => Exec['dovecot']
-  }
+  ensure_packages([$mailpackages])
 
   exec { 'dovecot':
     command     => 'echo "dovecot packages are installed"',
     path        => '/usr/sbin:/bin:/usr/bin:/sbin',
     logoutput   => true,
     refreshonly => true,
+    require     => Package[$mailpackages],
   }
 
   service { 'dovecot':

--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -12,6 +12,8 @@ class dovecot::mail (
   $mailstoretype           = 'maildir',
   $userhome                = '/srv/vmail',
   $mailstorepath           = '/srv/vmail/%d/%n/',
+  # Set mailplugins to undef in the calling class
+  # if no plugins are being used.
   $mailplugins             = 'quota',
   $manage_mbox_read_locks  = 'fcntl',
   $manage_mbox_write_locks = 'dotlock fcntl'

--- a/manifests/passwdfile.pp
+++ b/manifests/passwdfile.pp
@@ -4,8 +4,8 @@ class dovecot::passwdfile (
   $username_format = "%u",
   $passwdfilename = "/etc/dovecot/dovecot-passdb"
 ) {
-  file { "/etc/dovecot/dovecot-passwdfile.conf.ext":
-    ensure  => present,
+  file { "/etc/dovecot/conf.d/auth-passwdfile.conf.ext":
+    ensure  => file,
     content => template('dovecot/auth-passwdfile.conf.ext'),
     mode    => '0600',
     owner   => root,
@@ -18,6 +18,6 @@ class dovecot::passwdfile (
       "set include 'auth-passwdfile.conf.ext'",
       "rm  include[ . = 'auth-system.conf.ext']",
     ],
-    require => File["/etc/dovecot/dovecot-passwdfile.conf.ext"]
+    require => File["/etc/dovecot/conf.d/auth-passwdfile.conf.ext"]
   }
 }

--- a/templates/auth-passwdfile.conf.ext
+++ b/templates/auth-passwdfile.conf.ext
@@ -6,10 +6,10 @@
 
 passdb {
   driver = passwd-file
-  args = scheme=<% @authscheme -%> username_format=<% @username_format -%> <% @passwdfilename -%>
+  args = scheme=<%= @authscheme %> username_format=<%= @username_format %> <%= @passwdfilename %>
 }
 
 userdb {
   driver = passwd-file
-  args = username_format=<% @username_format -%> <% @passwdfilename -%>
+  args = username_format=<%= @username_format %> <%= @passwdfilename %>
 }


### PR DESCRIPTION
I couldn't get the module to actually run because the package was defined with the same name several times in RHEL. Updated the mailpackages so that its called once. I wrote the template for auth-passwd incorrectly so this has been updated as well. All tested in CentOS 6.5. 

*\* ensure_packages([$mailpackages]) requires puppet/stdlib be installed.
