### PR TITLE
Update Augeas lenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tmp
 _yardoc
 doc/
 Gemfile.lock
+spec/fixtures/
+.idea/

--- a/manifests/config/augeas.pp
+++ b/manifests/config/augeas.pp
@@ -1,26 +1,29 @@
-# augeas lenses
+# == Class: dovecot::config::augeas
+#
+# Update some Augeas lenses, when a really old Augeas release (< 1.0.0) is installed.
+#
+# NOTE: we should consider removing this in the future, since most # distros are on Augeas > 1 now, and even PuppetLabs
+# ships those packages.
+#
 class dovecot::config::augeas {
-  file { '/usr/share/augeas/lenses/dist/dovecot.aug':
-    ensure => present,
-    source => 'puppet:///modules/dovecot/dovecot.aug',
-    owner  => root,
-    group  => root,
-    mode   => '0644'
-  }
+  if (versioncmp($::augeasversion, '1.0.0') < 0) {
+    File {
+      ensure => file,
+      owner  => root,
+      group  => root,
+      mode   => '0644'
+    }
+    file { '/usr/share/augeas/lenses/dist/dovecot.aug':
+      source => 'puppet:///modules/dovecot/dovecot.aug',
+    }
 
-  file { '/usr/share/augeas/lenses/dist/build.aug':
-    ensure => present,
-    source => 'puppet:///modules/dovecot/build.aug',
-    owner  => root,
-    group  => root,
-    mode   => '0644'
-  }
+    file { '/usr/share/augeas/lenses/dist/build.aug':
+      source => 'puppet:///modules/dovecot/build.aug',
+    }
 
-  file { '/usr/share/augeas/lenses/dist/util.aug':
-    ensure => present,
-    source => 'puppet:///modules/dovecot/util.aug',
-    owner  => root,
-    group  => root,
-    mode   => '0644'
+    file { '/usr/share/augeas/lenses/dist/util.aug':
+      source => 'puppet:///modules/dovecot/util.aug',
+    }
+
   }
 }


### PR DESCRIPTION
The lenses weren't working on an Ubuntu 14.04, so I pulled the latest versions
from Augeas' GitHub.

I'm not sure if that might cause problems on other OSes.
