### PR TITLE
Correct dependencies on package/service

### DIFF
--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -62,7 +62,8 @@ class dovecot::mail (
       mode    => '0644',
       owner   => root,
       group   => root,
-      before  => Exec['dovecot'],
+      require => Exec['dovecot'],
+      notify  => Service['dovecot'],
     }
   }
 


### PR DESCRIPTION
During tests I noticed that the dependency is wrong, which can lead to an error state when Puppet tries to create that file before dovecot is actually installed.
