### PR TITLE
Add missing ssl_protocols config option

### DIFF
--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -7,6 +7,7 @@ class dovecot::ssl (
   $ssl_key_pass_file = false,
   $ssl_cipher_list   = false,
   $ssl_prefer_server_ciphers = false,
+  $ssl_protocols = false,
 ) {
   include dovecot
 
@@ -53,6 +54,13 @@ class dovecot::ssl (
     dovecot::config::dovecotcfsingle { 'ssl_prefer_server_ciphers':
       config_file => 'conf.d/10-ssl.conf',
       value       => $ssl_prefer_server_ciphers,
+    }
+  }
+  
+  if $ssl_protocols != false {
+    dovecot::config::dovecotcfsingle { 'ssl_protocols':
+      config_file => 'conf.d/10-ssl.conf',
+      value       => $ssl_protocols,
     }
   }
 }


### PR DESCRIPTION
Dovecot >= 2.1 adds the ability to disable ssl protocols via this config option
