### PR TITLE
Change ordering for dovecot::mail manage_mailboxfile section

### DIFF
--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -23,7 +23,7 @@ class dovecot::ldap (
     mode    => '0600',
     owner   => root,
     group   => dovecot,
-    before  => Exec['dovecot'],
+    require => Exec['dovecot'],
   }
 
   file { '/etc/dovecot/dovecot-ldap-userdb.conf.ext':
@@ -32,7 +32,7 @@ class dovecot::ldap (
     mode    => '0600',
     owner   => root,
     group   => dovecot,
-    before  => Exec['dovecot'],
+    require => Exec['dovecot'],
   }
 
   file { '/etc/dovecot/conf.d/auth-ldap.conf.ext':
@@ -41,7 +41,7 @@ class dovecot::ldap (
     mode    => '0600',
     owner   => root,
     group   => dovecot,
-    before  => Exec['dovecot'],
+    require => Exec['dovecot'],
   }
 
   dovecot::config::dovecotcfmulti { 'ldapauth':

--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -62,7 +62,7 @@ class dovecot::mail (
       mode    => '0644',
       owner   => root,
       group   => root,
-      before  => Exec['dovecot'],
+      require => Exec['dovecot'],
     }
   }
 


### PR DESCRIPTION
Slight change...

But this was failing because you cannot `ensure => present` when the package has not yet been installed... `/etc/dovecot` does not exists yet
