### PR TITLE
fixes https://github.com/mjhas/dovecot/issues/40 on Jessie.

### DIFF
--- a/manifests/config/augeas.pp
+++ b/manifests/config/augeas.pp
@@ -1,26 +1,28 @@
 # augeas lenses
 class dovecot::config::augeas {
-  file { '/usr/share/augeas/lenses/dist/dovecot.aug':
-    ensure => present,
-    source => 'puppet:///modules/dovecot/dovecot.aug',
-    owner  => root,
-    group  => root,
-    mode   => '0644'
-  }
+  if $::dovecot::needs_dovecot_lens {
+    file { '/usr/share/augeas/lenses/dist/dovecot.aug':
+      ensure => present,
+      source => 'puppet:///modules/dovecot/dovecot.aug',
+      owner  => root,
+      group  => root,
+      mode   => '0644'
+    }
 
-  file { '/usr/share/augeas/lenses/dist/build.aug':
-    ensure => present,
-    source => 'puppet:///modules/dovecot/build.aug',
-    owner  => root,
-    group  => root,
-    mode   => '0644'
-  }
+    file { '/usr/share/augeas/lenses/dist/build.aug':
+      ensure => present,
+      source => 'puppet:///modules/dovecot/build.aug',
+      owner  => root,
+      group  => root,
+      mode   => '0644'
+    }
 
-  file { '/usr/share/augeas/lenses/dist/util.aug':
-    ensure => present,
-    source => 'puppet:///modules/dovecot/util.aug',
-    owner  => root,
-    group  => root,
-    mode   => '0644'
+    file { '/usr/share/augeas/lenses/dist/util.aug':
+      ensure => present,
+      source => 'puppet:///modules/dovecot/util.aug',
+      owner  => root,
+      group  => root,
+      mode   => '0644'
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,8 @@ class dovecot(
     'Redhat' => ['dovecot',]
   }
 
+  $needs_dovecot_lens = $::osfamily != 'Debian' or $::lsbmajdistrelease < 8
+
   ensure_packages([$mailpackages], { 'configfiles' => $package_configfiles })
 
   exec { 'dovecot':


### PR DESCRIPTION
The build.aug gets overwritten my this dovecot module, the yum.aug breaks
as it uses Build.combine_three_opt from the overwritten build.aug
